### PR TITLE
fix to compilation error on MSYS2 MINGW:

### DIFF
--- a/src/solid/devices/backends/win/winbattery.cpp
+++ b/src/solid/devices/backends/win/winbattery.cpp
@@ -20,6 +20,7 @@
 #include "winbattery.h"
 #include "windevicemanager_p.h"
 
+#include <devpropdef.h>
 #include <setupapi.h>
 #include <batclass.h>
 #include <devguid.h>


### PR DESCRIPTION
  C:/msys64/mingw64/x86_64-w64-mingw32/include/setupapi.h:1879:119: error: 'DEVPROPKEY' does not name a type
    WINSETUPAPI WINBOOL WINAPI SetupDiGetDevicePropertyW(HDEVINFO DeviceInfoSet, PSP_DEVINFO_DATA DeviceInfoData, const DEVPROPKEY *PropertyKey, DEVPROPTYPE *PropertyType, PBYTE PropertyBuffer, DWORD PropertyBufferSize, PDWORD RequiredSize, DWORD Flags);

DEVPROPKEY is defined in devpropdef.h so include it before setupapi.h

I'm not sure how this should be officially handled but it fixes my issue
