### PR TITLE
Battery recognition on gaming_input devices

### DIFF
--- a/src/solid/devices/backends/upower/upowerdevice.cpp
+++ b/src/solid/devices/backends/upower/upowerdevice.cpp
@@ -89,7 +89,13 @@ bool UPowerDevice::queryDeviceInterface(const Solid::DeviceInterface::Type &type
     case Solid::DeviceInterface::GenericInterface:
         return true;
     case Solid::DeviceInterface::Battery:
-        return (uptype == 2 || uptype == 3 || uptype == 5 || uptype == 6 || uptype == 7 || uptype == 8);
+        /* Every Device which is handled by Upower and which is not
+         * one of the following is a battery:
+         * UP_DEVICE_KIND_UNKNOWN (0)
+         * UP_DEVICE_KIND_LINE_POWER (1) or
+         * UP_DEVICE_KIND_MONITOR (4)
+         */
+        return (uptype != 0 && uptype != 1 && uptype != 4);
     default:
         return false;
     }


### PR DESCRIPTION
Necessary as discussed here:
https://forum.kde.org/viewtopic.php?f=204&t=151433&p=395938#p395938
Especially for this driver:
https://github.com/atar-axis/xpadneo